### PR TITLE
chore(postgrest_errors): 0.1.1

### DIFF
--- a/packages/postgrest_errors/CHANGELOG.md
+++ b/packages/postgrest_errors/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1
+
+- docs: PostgrestException constructor template macro ([#25](https://github.com/alestiago/postgrest_errors/pull/25))
+
 # 0.1.0+3
 
 - docs: fix erroneous README logo link ([#23](https://github.com/alestiago/postgrest_errors/pull/23))

--- a/packages/postgrest_errors/pubspec.yaml
+++ b/packages/postgrest_errors/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest_errors
 description: A generated typed collection of all PostgREST error definitions.
-version: 0.1.0+3
+version: 0.1.1
 repository: https://github.com/alestiago/postgrest_errors/tree/main/packages/postgrest_errors
 issue_tracker: https://github.com/alestiago/postgrest_errors/issues
 documentation: https://github.com/alestiago/postgrest_errors/blob/main/packages/postgrest_errors/README.md


### PR DESCRIPTION
# 0.1.1

- docs: PostgrestException constructor template macro ([#25](https://github.com/alestiago/postgrest_errors/pull/25))